### PR TITLE
delete revision tiddlers made by the plainrevs plugin by jd

### DIFF
--- a/$__plugins_kookma_trashbin_macros_move-to-trashbin.json
+++ b/$__plugins_kookma_trashbin_macros_move-to-trashbin.json
@@ -1,0 +1,12 @@
+[
+    {
+        "created": "20190710071039480",
+        "creator": "HC Haase",
+        "title": "$:/plugins/kookma/trashbin/macros/move-to-trashbin",
+        "modified": "20190917122911680",
+        "tags": "$:/tags/Macro",
+        "type": "text/vnd.tiddlywiki",
+        "text": "\\define trashTidName() <<unusedtitle baseName:\"$(trashTiddler)$\">>\n\n\\define move-to-trashbin(tiddler)\n<$vars trashTiddler={{{ [<__tiddler__>addprefix[$:/trashbin/]] }}}>\n<$wikify name=\"trashTid\" text=<<trashTidName>> >\n<$list filter=\"[<__tiddler__>fields[]]\" variable=\"fieldName\">\n<$action-setfield \n $tiddler=<<trashTid>>\n $index=<<fieldName>>\n $value={{{[<__tiddler__>get<fieldName>] }}}\n/>\n</$list>\n<$action-setfield $tiddler=<<trashTid>> tags=\"$:/tags/trashbin\"/>\n</$wikify>\n<$action-sendmessage $message=\"tm-close-tiddler\" $param=<<__tiddler__>> />\n<$action-deletetiddler $tiddler=<<__tiddler__>> />\n</$vars>\n<$action-deletetiddler $filter=\"[<currentTiddler>listed[]prefix[$:/rev]!has[pin]]\"/>\n\\end\n",
+        "modifier": "HC Haase"
+    }
+]

--- a/$__plugins_kookma_trashbin_sidebar-tab.tid
+++ b/$__plugins_kookma_trashbin_sidebar-tab.tid
@@ -1,0 +1,43 @@
+caption: Trashbin
+created: 20190613131234955
+creator: HC Haase
+modified: 20190918110704098
+modifier: HC Haase
+tags: $:/tags/MoreSideBar
+title: $:/plugins/kookma/trashbin/sidebar-tab
+type: text/vnd.tiddlywiki
+
+\define show-link()
+<$link to=<<currentTiddler>> ><$text text={{{ [<currentTiddler>removeprefix[$:/trashbin/]] }}} /> </$link>
+\end
+
+\define recycle-button()
+{{||$:/plugins/kookma/trashbin/viewtoolbar-button}}
+\end
+
+\define delete-button()
+<$button class="tc-btn-invisible" tooltip="Delete permanently">
+{{$:/plugins/kookma/trashbin/images/times.svg}}
+<$action-deletetiddler $tiddler=<<currentTiddler>> />
+</$button>
+\end
+
+<div class="kk-trahbin-ui">
+
+<span class="kk-trahbin-ui-controls">
+<<trashbin-empty-bin>> <<restore-all>>
+</span>
+
+<$list filter='[tag[$:/tags/trashbin]limit[1]]'  variable=null>
+<$count filter='[tag[$:/tags/trashbin]]'/> items in trash.
+</$list>
+<$list filter="[tag[$:/tags/trashbin]search:title[$:/trashbin/]sortan[]]" emptyMessage="Trash bin is empty">
+
+# <div class="kk-trashbin-row">
+	<div class="kk-trashbin-link"><<show-link>></div>
+	<div class="kk-trashbin-recycle"><<recycle-button>></div>
+	<div class="kk-trashbin-delete"><<delete-button>></div>
+</div>
+</$list>
+
+</div>

--- a/$__plugins_kookma_trashbin_sidebar-tab.tid
+++ b/$__plugins_kookma_trashbin_sidebar-tab.tid
@@ -32,8 +32,7 @@ type: text/vnd.tiddlywiki
 <$count filter='[tag[$:/tags/trashbin]]'/> items in trash.
 </$list>
 <$list filter="[tag[$:/tags/trashbin]search:title[$:/trashbin/]sortan[]]" emptyMessage="Trash bin is empty">
-
-# <div class="kk-trashbin-row">
+<div class="kk-trashbin-row">
 	<div class="kk-trashbin-link"><<show-link>></div>
 	<div class="kk-trashbin-recycle"><<recycle-button>></div>
 	<div class="kk-trashbin-delete"><<delete-button>></div>


### PR DESCRIPTION
I use jd's revision plugin and also want to use your trash bin plugin, but that would leave revision tidderls "floating free" without any reference tiddler, thus I made your plugin delete them. I would be better to also move them to the trashbin, but I dont have the skills to do that, and this is better than letting them fill up your wiki.

I added a line to also delete any revision tiddlers made by the plainrevs plugin by jd.

NB: the revision tiddlers are NOT moved to trash, permanently deleted!!
( I dont have the insight to do that)

ps. sorry for the clumsy pr. I cant find the tiddler in your repo. I hope it makes sense for your. I just copied a line form jd's plugin into the tiddler.